### PR TITLE
OpenDRT Tweaks

### DIFF
--- a/OpenDRT.ctl
+++ b/OpenDRT.ctl
@@ -1293,6 +1293,12 @@ void ART_main(varying float r, varying float g, varying float b,
                          tn_gb,
                          pt_hdr);
 
+  if (display_gamut == 0) {
+      rgb = vdot(matrix_xyz_to_rec2020, vdot(matrix_rec709_to_xyz, rgb));
+  } else if (display_gamut == 1) {
+    rgb = vdot(matrix_xyz_to_rec2020, vdot(matrix_p3d65_to_xyz, rgb));
+  }
+
   float outscale = tn_Lp / 100.0;
 
   rout = rgb.x * outscale;


### PR DESCRIPTION
For your consideration...

- It looks like we lost the gamut conversion to Rec.2020 at the end of the CTL, which was causing the over-saturated colors to come back again. Fixed in 22bb680edd282cff14abd53e8aaa26b0e3acc5af
- Tweak "gain" parameter [af52061](https://github.com/artpixls/ART-ctlscripts/pull/2/commits/af52061bc079131251320de72b9b73a2ce1bd21e): I think it would be preferable if we
  1. Called this parameter what it is: an exposure adjustment
  2. Set the parameter's default value to compensate by `log2(0.18/0.111)=2^0.697437`, so that the tonescale presets which map 0.18->0.111 through the transform will be compensated and middle grey will remain unchanged. 
  3. Having this as the default value will still allow the user to easily set the exposure compensation to 0.0 and have the "default" / "original" behavior of OpenDRT if they desire.